### PR TITLE
Save cell height on cell creation

### DIFF
--- a/Sources/Intermodular/Helpers/UIKit/UIHostingTableViewController.swift
+++ b/Sources/Intermodular/Helpers/UIKit/UIHostingTableViewController.swift
@@ -270,6 +270,13 @@ public class UIHostingTableViewController<SectionModel: Identifiable, Item: Iden
         
         view.update()
         
+        let height = cell
+            .contentView
+            .systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+            .height
+
+        _rowContentHeightCache[cell.item.id] = height
+        
         return view
     }
     


### PR DESCRIPTION
This change aims to reduce the number of times a view has to be constructed.
This reduces view allocations by nearly half by caching height for the heightForRowAt call.