### PR TITLE
Add setter method of textAlignment

### DIFF
--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -278,6 +278,10 @@ extension CocoaTextField {
     public func placeholder(_ placeholder: String) -> Self {
         then({ $0.placeholder = placeholder })
     }
+    
+    public func textAlignment(_ textAlignment: TextAlignment) -> Self {
+        then({ $0.textAlignment = textAlignment })
+    }
 }
 
 extension CocoaTextField where Label == Text {


### PR DESCRIPTION
This changes aims to add missing setter method of textAlignment to CocoaTextField. No breaking Changes.