### PR TITLE
Add borderStyle property to CocoaTextField

### DIFF
--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -24,6 +24,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
     private var kerning: CGFloat?
     private var keyboardType: UIKeyboardType = .default
     private var placeholder: String?
+    private var borderStyle: UITextField.BorderStyle = .none
     
     @Environment(\.font) var font
     
@@ -48,7 +49,8 @@ public struct CocoaTextField<Label: View>: CocoaView {
                 inputView: inputView,
                 kerning: kerning,
                 keyboardType: keyboardType,
-                placeholder: placeholder
+                placeholder: placeholder,
+                borderStyle: borderStyle
             )
         }
     }
@@ -74,6 +76,7 @@ public struct _CocoaTextField: UIViewRepresentable {
     var kerning: CGFloat?
     var keyboardType: UIKeyboardType
     var placeholder: String?
+    var borderStyle: UITextField.BorderStyle
     
     public class Coordinator: NSObject, UITextFieldDelegate {
         var base: _CocoaTextField
@@ -177,6 +180,8 @@ public struct _CocoaTextField: UIViewRepresentable {
             uiView.placeholder = nil
         }
         
+        uiView.borderStyle = borderStyle
+        
         uiView.text = text
         uiView.textAlignment = .init(multilineTextAlignment)
         
@@ -275,6 +280,10 @@ extension CocoaTextField {
     
     public func placeholder(_ placeholder: String) -> Self {
         then({ $0.placeholder = placeholder })
+    }
+    
+    public func borderStyle(_ borderStyle: UITextField.BorderStyle) -> Self {
+        then({ $0.borderStyle = borderStyle })
     }
 }
 


### PR DESCRIPTION
**What I do**
Add borderStyle property for CocoaTextField to change borderStyle.

**What is the problem**
SwiftUI have `.textFieldStyle(TextFieldStyle:)` modifier but It inject a value to internal environment value. I mean that we can't get the value by using @Environment property wrapper and we can't change borderStyle with `CocoaTextField`.

**Doc that describe about environment**
```swift
@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
extension View {

    /// Sets the style for `TextField` within the environment of `self`.
    public func textFieldStyle<S>(_ style: S) -> some View where S : TextFieldStyle
}
```