### PR TITLE
Fix `SearchBar` cancel button typo

### DIFF
--- a/Sources/Intramodular/Search/SearchBar.swift
+++ b/Sources/Intramodular/Search/SearchBar.swift
@@ -172,7 +172,7 @@ extension SearchBar {
     }
     
     public func showsCancelButton(_ shows: Bool) -> Self {
-        then({ $0.showsCancelButton = showsCancelButton })
+        then({ $0.showsCancelButton = shows })
     }
     
     public func onCancel(perform action: @escaping () -> Void) -> Self {


### PR DESCRIPTION
I found a typo at `SearchBar.showsCancelButton`, it always set to the default value no matter I changed it to true.