### PR TITLE
Update CocoaScrollView.Configuration.swift

### DIFF
--- a/Sources/Intramodular/Bridged/CocoaScrollView.Configuration.swift
+++ b/Sources/Intramodular/Bridged/CocoaScrollView.Configuration.swift
@@ -70,6 +70,8 @@ extension UIScrollView {
     func configure<Content: View>(
         with configuration: CocoaScrollViewConfiguration<Content>
     ) {
+		showsVerticalScrollIndicator = configuration.showsIndicators
+		showsHorizontalScrollIndicator = configuration.showsIndicators
         alwaysBounceVertical = configuration.alwaysBounceVertical
         alwaysBounceHorizontal = configuration.alwaysBounceHorizontal
         isDirectionalLockEnabled = configuration.isDirectionalLockEnabled


### PR DESCRIPTION
Init the CocoaScrollView with showsIndicator=false had no effect before.