### PR TITLE
Add ShareSheet (Port of UIActivityView)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Documentation is a currently a work-in-progress!
 
 # Why
 
-The goal of this project is to **complement** the SwiftUI standard library, offering hundreds of extensions and views that empower you, the developer, to build applications with the ease promised by the revolution that is SwiftUI. 
+The goal of this project is to **complement** the SwiftUI standard library, offering hundreds of extensions and views that empower you, the developer, to build applications with the ease promised by the revolution that is SwiftUI.
 
 This project is also **by far** the most complete port of missing UIKit/AppKit functionality, striving it to deliver in most Apple-like fashion possible.
 
@@ -29,10 +29,11 @@ This project is also **by far** the most complete port of missing UIKit/AppKit f
 | `UIViewControllerTransitioningDelegate` | -            | `CocoaHostingControllerTransitioningDelegate` |
 | `UIVisualEffectView`                    | -            | `VisualEffectView`                            |
 | `UIWindow`                              | -            | `WindowOverlay`                               |
+| `UIActivityView`                        | -            | `ShareSheet` or `.shareSheet`                 |
 
-# Requirements 
+# Requirements
 
-- iOS 13, macOS 10.15, tvOS 13, or watchOS 6 
+- iOS 13, macOS 10.15, tvOS 13, or watchOS 6
 - Swift 5.1
 - Xcode 11
 
@@ -49,7 +50,7 @@ The preferred way of installing SwiftUIX is via the [Swift Package Manager](http
 
 # Usage
 
-SwiftUIX's documentation is available via the [repository wiki](https://github.com/SwiftUIX/SwiftUIX/wiki). 
+SwiftUIX's documentation is available via the [repository wiki](https://github.com/SwiftUIX/SwiftUIX/wiki).
 
 # Contributing
 
@@ -63,6 +64,6 @@ SwiftUIX is licensed under the [MIT License](https://vmanot.mit-license.org).
 
 SwiftUIX is a project of [@vmanot](https://github.com/vmanot).
 
-# Support 
+# Support
 
 SwiftUIX is and will always be free and open. Maintaining SwiftUIX, however, is a time-consuming endeavour. If you're reliant on SwiftUIX for your app/project and would like to see it grow, consider contributing/donating as way to help.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is also **by far** the most complete port of missing UIKit/AppKit f
 | UIKit                                   | SwiftUI      | SwiftUIX                                      |
 | --------------------------------------- | ------------ | --------------------------------------------- |
 | `UIActivityIndicatorView`               | -            | `ActivityIndicator`                           |
+| `UIActivityView`                        | -            | `ShareSheet` or `.shareSheet`                 |
 | `UIBlurEffect`                          | -            | `BlurEffectView`                              |
 | `UICollectionView`                      | -            | `CollectionView`                              |
 | `UIDeviceOrientation`                   | -            | `DeviceLayoutOrientation`                     |
@@ -29,7 +30,6 @@ This project is also **by far** the most complete port of missing UIKit/AppKit f
 | `UIViewControllerTransitioningDelegate` | -            | `CocoaHostingControllerTransitioningDelegate` |
 | `UIVisualEffectView`                    | -            | `VisualEffectView`                            |
 | `UIWindow`                              | -            | `WindowOverlay`                               |
-| `UIActivityView`                        | -            | `ShareSheet` or `.shareSheet`                 |
 
 # Requirements
 

--- a/Sources/Intramodular/Sharing/ShareSheet.swift
+++ b/Sources/Intramodular/Sharing/ShareSheet.swift
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Vatsal Manot
+//
+
+import SwiftUI
+
+#if os(iOS)
+
+/// A SwiftUI port of `UIActivityView`.
+public struct ShareSheet {
+    public typealias Callback = (_ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?) -> Void
+    
+    private let activityItems: [Any]
+    
+    private let applicationActivities: [UIActivity]?
+    private let excludedActivityTypes: [UIActivity.ActivityType]?
+    
+    private let callback: Callback?
+    
+    public init(_ activityItems: [Any], applicationActivities: [UIActivity]? = nil, excludedActivityTypes: [UIActivity.ActivityType]? = nil, callback: Callback? = nil) {
+        self.activityItems = activityItems
+        self.applicationActivities = applicationActivities
+        self.excludedActivityTypes = excludedActivityTypes
+        self.callback = callback
+    }
+}
+
+extension ShareSheet : UIViewControllerRepresentable {
+    
+    public func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+        
+        controller.excludedActivityTypes = excludedActivityTypes
+        controller.completionWithItemsHandler = callback
+        
+        return controller
+    }
+    
+    public func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        
+    }
+}
+
+extension View {
+    
+    /// Presents a share sheet
+    public func shareSheet(isPresented: Binding<Bool>, _ activityItems: [Any], applicationActivities: [UIActivity]? = nil, excludedActivityTypes: [UIActivity.ActivityType]? = nil, callback: ShareSheet.Callback? = nil) -> some View {
+        
+        self.sheet(isPresented: isPresented) {
+            ShareSheet(activityItems, applicationActivities: applicationActivities, excludedActivityTypes: excludedActivityTypes, callback: callback)
+        }
+        
+    }
+    
+}
+
+#endif


### PR DESCRIPTION
I added a `ShareSheet` View, which is a port of `UIActivityView`.

You can call one using:
```Swift
ShareSheet([Any])
// OR
ShareSheet([Any], applicationActivities: [UIActivity]?, excludedActivityTypes: [UIActivity.ActivityType]?, callback: ShareSheet.Callback?)
```
or
```Swift
Text("View 1").shareSheet(isPresented: Binding<Bool>, [Any])
// OR
Text("View 2").shareSheet(isPresented: Binding<Bool>, [Any], applicationActivities: [UIActivity]?, excludedActivityTypes: [UIActivity.ActivityType]?, callback: ShareSheet.Callback?)
```

I also added it to the README.md under `UIActivityIndicatorView`.

If you want me to change anything, like the `init()`s or filename, just tell me! 