### PR TITLE
Update OptionalObservableObject.swift

### DIFF
--- a/Sources/Intramodular/Dynamic Properties/OptionalObservableObject.swift
+++ b/Sources/Intramodular/Dynamic Properties/OptionalObservableObject.swift
@@ -43,14 +43,17 @@ private final class OptionalObservableObject<ObjectType: ObservableObject>: Obse
     private var baseSubscription: AnyCancellable?
     
     fileprivate(set) var base: ObjectType? {
-        didSet {
-            baseSubscription = base?.objectWillChange.sink(receiveValue: { [unowned self] _ in
-                self.objectWillChange.send()
-            })
-        }
+        didSet { subscribe() }
     }
     
     init(base: ObjectType?) {
         self.base = base
+        subscribe()
+    }
+    
+    private func subscribe() {
+        baseSubscription = base?.objectWillChange.sink(receiveValue: { [unowned self] _ in
+            self.objectWillChange.send()
+        })
     }
 }


### PR DESCRIPTION
The problem is that didSet is not called in the initialization of the property, so if you gave a default value instead of nil and did not update the base before changing one of his properties, the changes did not affect the view. The solution was to simply add the subscription in the init.