### PR TITLE
Removing invalid character (%u3000)

### DIFF
--- a/Sources/Intramodular/Text/TextView.swift
+++ b/Sources/Intramodular/Text/TextView.swift
@@ -113,8 +113,8 @@ extension _TextView: UIViewRepresentable {
         }
         
         uiView.backgroundColor = nil
-
-　　　　　// As default font of UITextView is smaller than SwiftUI. `.preferredFont(forTextStyle: .body)` is required when environment's font is nil. 
+        
+        // As default font of UITextView is smaller than SwiftUI. `.preferredFont(forTextStyle: .body)` is required when environment's font is nil. 
         uiView.font = context.environment.font?.toUIFont() ?? .preferredFont(forTextStyle: .body)
         #if !os(tvOS)
         uiView.isEditable = context.environment.isEnabled


### PR DESCRIPTION
One of the whitespace elements in this comment is %u3000, which Xcode considers invalid. 