### PR TITLE
CocoaTextField improvements

### DIFF
--- a/Sources/Intermodular/Extensions/SwiftUI/Alignment++.swift
+++ b/Sources/Intermodular/Extensions/SwiftUI/Alignment++.swift
@@ -23,3 +23,16 @@ extension Alignment {
         edges.map(isAligned(to:)).reduce(true, { $0 && $1 })
     }
 }
+
+extension HorizontalAlignment {
+    init(from alignment: TextAlignment) {
+        switch alignment {
+        case .center:
+            self = .center
+        case .leading:
+            self = .leading
+        case .trailing:
+            self = .trailing
+        }
+    }
+}

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -30,6 +30,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
     private var textContentType: UITextContentType?
     
     @Environment(\.font) var font
+    @Environment(\.multilineTextAlignment) var multilineTextAlignment: TextAlignment
 
     @available(macCatalystApplicationExtension, unavailable)
     @available(iOSApplicationExtension, unavailable)
@@ -37,7 +38,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
     @ObservedObject var keyboard = Keyboard.main
     
     public var body: some View {
-        return ZStack(alignment: .topLeading) {
+        return ZStack(alignment: Alignment(horizontal: .init(from: multilineTextAlignment), vertical: .top)) {
             if placeholder == nil {
                 label
                     .font(uiFont.map(Font.init) ?? font)

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -26,9 +26,10 @@ public struct CocoaTextField<Label: View>: CocoaView {
     private var kerning: CGFloat?
     private var keyboardType: UIKeyboardType = .default
     private var placeholder: String?
+    private var textColor: UIColor?
     
     @Environment(\.font) var font
-    
+
     @available(macCatalystApplicationExtension, unavailable)
     @available(iOSApplicationExtension, unavailable)
     @available(tvOSApplicationExtension, unavailable)
@@ -85,7 +86,8 @@ public struct _CocoaTextField: UIViewRepresentable {
     var kerning: CGFloat?
     var keyboardType: UIKeyboardType
     var placeholder: String?
-    
+    var textColor: UIColor?
+
     public class Coordinator: NSObject, UITextFieldDelegate {
         var base: _CocoaTextField
         
@@ -146,7 +148,8 @@ public struct _CocoaTextField: UIViewRepresentable {
         
         uiView.borderStyle = borderStyle
         uiView.font = uiFont ?? font?.toUIFont()
-        
+        uiView.textColor = textColor
+
         if let kerning = kerning {
             uiView.defaultTextAttributes.updateValue(kerning, forKey: .kern)
         }
@@ -299,6 +302,10 @@ extension CocoaTextField {
     
     public func placeholder(_ placeholder: String) -> Self {
         then({ $0.placeholder = placeholder })
+    }
+
+    public func textColor(_ textColor: UIColor?) -> Self {
+        then({ $0.textColor = textColor })
     }
 }
 

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -58,7 +58,8 @@ public struct CocoaTextField<Label: View>: CocoaView {
                 inputView: inputView,
                 kerning: kerning,
                 keyboardType: keyboardType,
-                placeholder: placeholder
+                placeholder: placeholder,
+                textColor: textColor
             )
         }
     }

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -27,6 +27,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
     private var keyboardType: UIKeyboardType = .default
     private var placeholder: String?
     private var textColor: UIColor?
+    private var textContentType: UITextContentType?
     
     @Environment(\.font) var font
 
@@ -59,7 +60,8 @@ public struct CocoaTextField<Label: View>: CocoaView {
                 kerning: kerning,
                 keyboardType: keyboardType,
                 placeholder: placeholder,
-                textColor: textColor
+                textColor: textColor,
+                textContentType: textContentType
             )
         }
     }
@@ -88,6 +90,7 @@ public struct _CocoaTextField: UIViewRepresentable {
     var keyboardType: UIKeyboardType
     var placeholder: String?
     var textColor: UIColor?
+    var textContentType: UITextContentType?
 
     public class Coordinator: NSObject, UITextFieldDelegate {
         var base: _CocoaTextField
@@ -150,6 +153,9 @@ public struct _CocoaTextField: UIViewRepresentable {
         uiView.borderStyle = borderStyle
         uiView.font = uiFont ?? font?.toUIFont()
         uiView.textColor = textColor
+        if let textContentType = textContentType {
+            uiView.textContentType = textContentType
+        }
 
         if let kerning = kerning {
             uiView.defaultTextAttributes.updateValue(kerning, forKey: .kern)
@@ -307,6 +313,10 @@ extension CocoaTextField {
 
     public func textColor(_ textColor: UIColor?) -> Self {
         then({ $0.textColor = textColor })
+    }
+
+    public func textContentType(_ textContentType: UITextContentType?) -> Self {
+        then({ $0.textContentType = textContentType })
     }
 }
 


### PR DESCRIPTION
Following improvements over CocoaTextField:
- textColor support. Didn't figure out how to set that using Environment, it's locked inside SwiftUI, so added a property to hold color as UIColor, so no SwiftUI color conversion restrictions apply
- made placeholder label obey multilineTextAlignment, so it appears in the same place where text would appear