### PR TITLE
Added more documentation and examples for image picker

### DIFF
--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -18,9 +18,9 @@ To use the Image Picker, define a variable of type `Data` and pass it into `Imag
 	        }
 	}
 The above code looks like:
-<center>
+<p align="center">
 <Image src="https://i.imgur.com/1rhpwsl.png" height=600> 
-</center>
+	</p>
 	
 <br />
 

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -2,6 +2,7 @@
 The `ImagePicker` in SwiftUIX is a simple, efficient, and native SwiftUI way to display an equivalent of `UIImagePickerController`.
 
 <br />
+
 ## Usage Example
 To use the Image Picker, define a variable of type `Data` and pass it into `ImagePicker`. The user's picked image can be accessed from the variable.
 
@@ -22,6 +23,7 @@ The above code looks like:
 </center>
 	
 <br />
+
 ## Parameters
 `ImagePicker(data: , encoding:)`
 

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -16,11 +16,11 @@ To use the Image Picker, define a variable of type `Data` and pass it into `Imag
 	        }
 	}
 The above code looks like:
-<style> img{ box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1)}</style>
 <center>
 <Image src="https://i.imgur.com/1rhpwsl.png" height=600> 
 </center>
-##Parameters
+	
+## Parameters
 `ImagePicker(data: , encoding:)`
 
 
@@ -29,7 +29,8 @@ The `ImagePicker` takes in 2 parameters: `data` and `encoding`.
 The `data` parameter takes in a optional `Data` type binding. In the code example above, the value of variable `image` will be provided by the `ImagePicker`. If you want to display the result of the `ImagePicker`, simply use the `Image(data: )` initializer to convert the `Data` into an `Image`. 
 
 The `encoding` parameter is an `enum` that takes in either JPEG or PNG as the encoding format. PNG or Portable Network Graphics is a loseless format for images. JPEG offers the compression quality parameter that can be 1 (very low quality) or 100 (very high quality)
-##Source Code
+
+## Source Code
 The `ImagePicker` uses SwiftUI's built in `UIViewRepresentable` framework and wraps UIKit's `UIImagePickerController ` into a SwiftUI View object.
 
 	public struct ImagePicker: UIViewControllerRepresentable {

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -1,7 +1,7 @@
 ##  What is `ImagePicker`?
 The `ImagePicker` in SwiftUIX is a simple, efficient, and native SwiftUI way to display an equivalent of `UIImagePickerController`.
 
-
+<br />
 ## Usage Example
 To use the Image Picker, define a variable of type `Data` and pass it into `ImagePicker`. The user's picked image can be accessed from the variable.
 
@@ -21,7 +21,7 @@ The above code looks like:
 <Image src="https://i.imgur.com/1rhpwsl.png" height=600> 
 </center>
 	
-	
+<br />
 ## Parameters
 `ImagePicker(data: , encoding:)`
 

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -1,6 +1,7 @@
 ##  What is `ImagePicker`?
 The `ImagePicker` in SwiftUIX is a simple, efficient, and native SwiftUI way to display an equivalent of `UIImagePickerController`.
 
+
 ## Usage Example
 To use the Image Picker, define a variable of type `Data` and pass it into `ImagePicker`. The user's picked image can be accessed from the variable.
 
@@ -20,6 +21,7 @@ The above code looks like:
 <Image src="https://i.imgur.com/1rhpwsl.png" height=600> 
 </center>
 	
+	
 ## Parameters
 `ImagePicker(data: , encoding:)`
 
@@ -28,6 +30,7 @@ The `ImagePicker` takes in 2 parameters: `data` and `encoding`.
 The `data` parameter takes in a optional `Data` type binding. In the code example above, the value of variable `image` will be provided by the `ImagePicker`. If you want to display the result of the `ImagePicker`, simply use the `Image(data: )` initializer to convert the `Data` into an `Image`. 
 
 The `encoding` parameter is an `enum` that takes in either JPEG or PNG as the encoding format. PNG or Portable Network Graphics is a loseless format for images. JPEG offers the compression quality parameter that can be 1 (very low quality) or 100 (very high quality)
+
 
 ## Source Code
 The `ImagePicker` uses SwiftUI's built in `UIViewRepresentable` framework and wraps UIKit's `UIImagePickerController ` into a SwiftUI View object.

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -1,7 +1,7 @@
 ##  What is `ImagePicker`?
 The `ImagePicker` in SwiftUIX is a simple, efficient, and native SwiftUI way to display an equivalent of `UIImagePickerController`.
 
-##Usage Example
+## Usage Example
 To use the Image Picker, define a variable of type `Data` and pass it into `ImagePicker`. The user's picked image can be accessed from the variable.
 
 	struct ContentView: View {

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -1,0 +1,107 @@
+##  What is `ImagePicker`?
+The `ImagePicker` in SwiftUIX is a simple, efficient, and native SwiftUI way to display an equivalent of `UIImagePickerController`.
+
+##Usage Example
+To use the Image Picker, define a variable of type `Data` and pass it into `ImagePicker`. The user's picked image can be accessed from the variable.
+
+	struct ContentView: View {
+	    @State var image:Data?
+	    var body: some View {
+	        ImagePicker(data: $image, encoding: .png)
+	            Image(data: image!)!
+	                .resizable()
+	                .aspectRatio(contentMode: .fill)
+	                .frame(width:200,height:200)
+	                .clipped()
+	        }
+	}
+The above code looks like:
+<style> img{ box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1)}</style>
+<center>
+<Image src="https://i.imgur.com/1rhpwsl.png" height=600> 
+</center>
+##Parameters
+`ImagePicker(data: , encoding:)`
+
+
+The `ImagePicker` takes in 2 parameters: `data` and `encoding`. 
+
+The `data` parameter takes in a optional `Data` type binding. In the code example above, the value of variable `image` will be provided by the `ImagePicker`. If you want to display the result of the `ImagePicker`, simply use the `Image(data: )` initializer to convert the `Data` into an `Image`. 
+
+The `encoding` parameter is an `enum` that takes in either JPEG or PNG as the encoding format. PNG or Portable Network Graphics is a loseless format for images. JPEG offers the compression quality parameter that can be 1 (very low quality) or 100 (very high quality)
+##Source Code
+The `ImagePicker` uses SwiftUI's built in `UIViewRepresentable` framework and wraps UIKit's `UIImagePickerController ` into a SwiftUI View object.
+
+	public struct ImagePicker: UIViewControllerRepresentable {
+	    public typealias UIViewControllerType = UIImagePickerController
+	    
+	    @Environment(\.presentationManager) var presentationManager
+	    
+	    @usableFromInline
+	    @Binding var data: Data?
+	    
+	    @usableFromInline
+	    let encoding: Image.Encoding
+	    
+	    @usableFromInline
+	    var allowsEditing = false
+	    
+	    @usableFromInline
+	    var sourceType: UIImagePickerController.SourceType = .photoLibrary
+	    
+	    public init(data: Binding<Data?>, encoding: Image.Encoding) {
+	        self._data = data
+	        self.encoding = encoding
+	    }
+	    
+	    public init(data: SetBinding<Data?>, encoding: Image.Encoding) {
+	        self._data = .init(set: data, defaultValue: nil)
+	        self.encoding = encoding
+	    }
+	    
+	    public func makeUIViewController(context: Context) -> UIViewControllerType {
+	        UIImagePickerController().then {
+	            $0.allowsEditing = allowsEditing
+	            $0.sourceType = sourceType
+	            
+	            $0.delegate = context.coordinator
+	        }
+	    }
+	    
+	    public func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+	        context.coordinator.base = self
+	        
+	        uiViewController.allowsEditing = allowsEditing
+	        uiViewController.sourceType = sourceType
+	    }
+	    
+	    public class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+	        var base: ImagePicker
+	        
+	        init(base: ImagePicker) {
+	            self.base = base
+	        }
+	        
+	        public var image: Image? {
+	            base.data.flatMap(Image.init(data:))
+	        }
+	        
+	        public func imagePickerController(
+	            _ picker: UIImagePickerController,
+	            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+	        ) {
+	            let image = (info[UIImagePickerController.InfoKey.editedImage] as? UIImage) ?? (info[UIImagePickerController.InfoKey.originalImage] as? UIImage)
+	            base.data = image?.data(using: base.encoding)
+	            
+	            base.presentationManager.dismiss()
+	        }
+	        
+	        public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+	            base.presentationManager.dismiss()
+	        }
+	    }
+	    
+	    public func makeCoordinator() -> Coordinator {
+	        Coordinator(base: self)
+	    }
+	}

--- a/ImagePickerDocumentation.md
+++ b/ImagePickerDocumentation.md
@@ -23,7 +23,6 @@ The above code looks like:
 ## Parameters
 `ImagePicker(data: , encoding:)`
 
-
 The `ImagePicker` takes in 2 parameters: `data` and `encoding`. 
 
 The `data` parameter takes in a optional `Data` type binding. In the code example above, the value of variable `image` will be provided by the `ImagePicker`. If you want to display the result of the `ImagePicker`, simply use the `Image(data: )` initializer to convert the `Data` into an `Image`. 


### PR DESCRIPTION
The markdown file named `ImagePickerDocumentation.md` in the top level directory replaces current documentation for image picker. Close #158.
@vmanot please review and copy into wiki. Thanks.