### PR TITLE
Added MotionEffectsView

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ While the project itself is stable and heavily being used in production, its doc
 | `UITableView`                           | `List`       | `CocoaList`                                |
 | `UITextField`                           | `TextField`  | `CocoaTextField`                           |
 | `UIModalPresentationStyle`              | -            | `ModalPresentationStyle`                   |
-| `UIInterpolatingMotionEffect`    | -            | `MotionEffectsView`                     |
+| `UIInterpolatingMotionEffect`           | -            | `MotionEffectsView`                        |
 | `UIViewControllerTransitioningDelegate` | -            | `UIHostingControllerTransitioningDelegate` |
 | `UIVisualEffectView`                    | -            | `VisualEffectView`                         |
 | `UIWindow`                              | -            | `WindowOverlay`                            |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ While the project itself is stable and heavily being used in production, its doc
 | `UITableView`                           | `List`       | `CocoaList`                                |
 | `UITextField`                           | `TextField`  | `CocoaTextField`                           |
 | `UIModalPresentationStyle`              | -            | `ModalPresentationStyle`                   |
+| `UIInterpolatingMotionEffect`    | -            | `MotionEffectsView`                     |
 | `UIViewControllerTransitioningDelegate` | -            | `UIHostingControllerTransitioningDelegate` |
 | `UIVisualEffectView`                    | -            | `VisualEffectView`                         |
 | `UIWindow`                              | -            | `WindowOverlay`                            |
@@ -105,6 +106,23 @@ While the project itself is stable and heavily being used in production, its doc
 
 - `Keyboard` - An object representing the keyboard. 
 - `View#padding(.keyboard) `- Pads this view with the active system height of the keyboard.
+
+### Motion
+
+- `MotionEffectsView` - Adds an offset to a view based on accelerometer data.
+
+```swift
+ZStack {
+    Text("Movere haec!")
+        .blur(radius: 10)
+        .opacity(0.4)
+    MotionEffectsView(magnitude: 15) {
+        Text("Movere haec!")
+    }
+}
+```
+
+  Note: does not work inside a `drawingGroup`, because that requires a non-moving view.
 
 ### Navigation
 

--- a/Sources/Intermodular/Helpers/UIKit/UIHostingMotionEffectsView.swift
+++ b/Sources/Intermodular/Helpers/UIKit/UIHostingMotionEffectsView.swift
@@ -1,0 +1,85 @@
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+import UIKit
+import SwiftUI
+
+/// Wrapper that applies a motion effect to an underlying hosting controller, 
+/// whose view will a `SwiftUI.View` (the `rootView` passed in at init time).
+open class UIHostingMotionEffectsView<Content: View>: UIView {
+    private let _motionEffectGroup: UIMotionEffectGroup
+    private let _hostingController: UIHostingController<Content>
+    
+    /// Inits a new `UIHostingMotionEffectsView`.
+    /// 
+    /// - Parameters:
+    ///   - magnitude: the maximum translation to use for the effect.
+    ///   - rootView: the `View` the effect will apply to.
+    public init(
+        magnitude: CGFloat,
+        rootView: Content
+    ) {
+        self._motionEffectGroup = Self.makeMotionEffectGroup(magnitude: magnitude)
+        
+        _hostingController = UIHostingController(rootView: rootView)
+        _hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        _hostingController.view.backgroundColor = nil
+        
+        super.init(frame: .zero)
+        
+        self.rootView = rootView
+        
+        addSubview(_hostingController.view)
+        self.setNeedsDisplay()
+        autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+    
+    /// No-op init required by the compiler.
+    /// 
+    /// - Parameter coder: no-op
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// The root view to apply the effect to.
+    public var rootView: Content {
+        get {
+            _hostingController.rootView
+        } set {
+            _hostingController.rootView = newValue
+            if _hostingController.view.motionEffects.isEmpty {
+                _hostingController.view.addMotionEffect(_motionEffectGroup)
+            }
+            _hostingController.view.setNeedsDisplay()
+        }
+    }
+    
+    /// Creates a `UIMotionEffectGroup` to apply to a `View`.
+    /// 
+    /// - Parameter magnitude: the maximum translation to use for the effect.
+    /// - Returns: a `UIMotionEffectGroup`.
+    private static func makeMotionEffectGroup(magnitude: CGFloat = 30) -> UIMotionEffectGroup {
+        let xMotion: UIInterpolatingMotionEffect = {
+            let min = CGFloat(-magnitude)
+            let max = CGFloat(magnitude)
+            let xMotionSetting = UIInterpolatingMotionEffect(keyPath: "layer.transform.translation.x", type: .tiltAlongHorizontalAxis)
+            xMotionSetting.maximumRelativeValue = max
+            xMotionSetting.minimumRelativeValue = min
+            return xMotionSetting
+        }()
+        
+        let yMotion: UIInterpolatingMotionEffect = {
+            let min = CGFloat(-magnitude)
+            let max = CGFloat(magnitude)
+            let xMotionSetting = UIInterpolatingMotionEffect(keyPath: "layer.transform.translation.y", type: .tiltAlongVerticalAxis)
+            xMotionSetting.maximumRelativeValue = max
+            xMotionSetting.minimumRelativeValue = min
+            return xMotionSetting
+        }()
+        
+        let motionEffectGroupSetting = UIMotionEffectGroup()
+        motionEffectGroupSetting.motionEffects = [xMotion,yMotion]
+        return motionEffectGroupSetting
+    }
+}
+
+#endif

--- a/Sources/Intramodular/Motion/MotionEffectsView.swift
+++ b/Sources/Intramodular/Motion/MotionEffectsView.swift
@@ -1,0 +1,45 @@
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+import UIKit
+import SwiftUI
+
+/// Adapts `UIKit`'s motion effects to `SwiftUI`.
+public struct MotionEffectsView<Content: View>: UIViewRepresentable {
+    public typealias UIViewType = UIHostingMotionEffectsView<Content>
+    
+    private let content: Content
+    private let magnitude: CGFloat
+    
+    /// Creates a view that applies a `UIMotionEffectGroup` that will
+    /// animate the supplied `content` based on accelerometer data with
+    /// a maximum offset defined by `magnitude`.
+    /// 
+    /// - Parameters:
+    ///   - magnitude: the maximum offset by which to limit the translation.
+    ///   - content: a `SwiftUI.View` to apply the effect to.
+    public init(
+        magnitude: CGFloat = 30,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.magnitude = magnitude
+        self.content = content()
+    }
+    
+    public func makeUIView(context: Context) -> UIViewType {
+        .init(magnitude: self.magnitude, rootView: content)
+    }
+    
+    public func updateUIView(_ view: UIViewType, context: Context) {
+        view.rootView = content
+    }
+}
+
+extension MotionEffectsView where Content == EmptyView {
+    public init() {
+        self.init() {
+            EmptyView()
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adapts UIKit's `UIInterpolatingMotionEffect` to SwiftUI. 

When I wanted to add this effect to an app I'm making, I had searched the net for awhile and not found anything good that could do this. The only thing close that I found was [this article on a blog called trailingClosure](https://trailingclosure.com/device-motion-effect/), however, this was a terrible implementation because it incurs really bad gimbal lock and causes the entire SwiftUI view hierarchy to redraw 60 times per second, killing the battery. 

Because Apple's documentation of SwiftUI is worse than carving my brain out with a rusty spoon, I was having trouble implementing a way to use Apple's `UIView.motionEffects` with `UIViewRepresentable`. But then, I remembered that I'd seen this repo at some point. So I looked in here, and saw that while you didn't have a wrapper for motion effects, meanwhile, you did provide some good examples of how to use `UIViewRepresentable` to wrap some visual effects.

Based on how you implemented `UIHostingVisualEffectBlurView` in this repo, I created `UIHostingMotionEffectsView`. Since your repo was so helpful, I figured that I should make a PR to add the motion effects view to your repo, if you're accepting PRs that is. 

Hopefully this will be useful to others looking to add this kind of motion effect to their SwiftUI views, in a way that doesn't kill the battery or cause the whole view hierarchy to constantly redraw.