### PR TITLE
Expose refresh control tint color of scroll view

### DIFF
--- a/Sources/Intramodular/Bridged/CocoaList.swift
+++ b/Sources/Intramodular/Bridged/CocoaList.swift
@@ -204,6 +204,11 @@ extension CocoaList {
     public func isRefreshing(_ isRefreshing: Bool) -> Self {
         then({ $0.scrollViewConfiguration.isRefreshing = isRefreshing })
     }
+
+    @inlinable
+    public func refreshControlTintColor(_ color: UIColor?) -> Self {
+      then({ $0.scrollViewConfiguration.refreshControlTintColor = color })
+    }
 }
 
 #endif

--- a/Sources/Intramodular/Bridged/CocoaScrollView.Configuration.swift
+++ b/Sources/Intramodular/Bridged/CocoaScrollView.Configuration.swift
@@ -32,6 +32,8 @@ public struct CocoaScrollViewConfiguration<Content: View> {
     var onRefresh: (() -> Void)?
     @usableFromInline
     var isRefreshing: Bool?
+    @usableFromInline
+    var refreshControlTintColor: UIColor?
     
     @available(tvOS, unavailable)
     @usableFromInline
@@ -97,7 +99,9 @@ extension UIScrollView {
                 
                 self.refreshControl = $0
             }
-            
+
+            refreshControl.tintColor = configuration.refreshControlTintColor
+
             if let isRefreshing = configuration.isRefreshing, refreshControl.isRefreshing != isRefreshing {
                 if isRefreshing {
                     refreshControl.beginRefreshing()

--- a/Sources/Intramodular/Bridged/CocoaScrollView.swift
+++ b/Sources/Intramodular/Bridged/CocoaScrollView.swift
@@ -72,6 +72,10 @@ extension CocoaScrollView {
     public func isRefreshing(_ isRefreshing: Bool) -> Self {
         then({ $0.configuration.isRefreshing = isRefreshing })
     }
+
+    public func refreshControlTintColor(_ color: UIColor?) -> Self {
+        then({ $0.configuration.refreshControlTintColor = color })
+    }
 }
 
 #endif

--- a/Sources/Intramodular/Collection/CollectionView.swift
+++ b/Sources/Intramodular/Collection/CollectionView.swift
@@ -162,6 +162,10 @@ extension CollectionView {
     public func isRefreshing(_ isRefreshing: Bool) -> Self {
         then({ $0.scrollViewConfiguration.isRefreshing = isRefreshing })
     }
+
+    public func refreshControlTintColor(_ color: UIColor?) -> Self {
+      then({ $0.scrollViewConfiguration.refreshControlTintColor = color })
+    }
 }
 
 #endif


### PR DESCRIPTION
So that we can customize the tint color of refresh controls of any type of bridged scroll views (i.e. CocoaList, CocoaScrollView and CollectionView)

Example use of the API is like this:
```swift
CocoaList {
  // Define items here
}
.refreshControlTintColor(.white)
.isRefreshing(viewModel.isRefreshing)
.onRefresh(viewModel.didPullToRefresh)
```