### PR TITLE
Update ImagePicker.md

### DIFF
--- a/Guides/Image Picker.md
+++ b/Guides/Image Picker.md
@@ -10,12 +10,12 @@ To use the Image Picker, define a variable of type `Data` and pass it into `Imag
 	    @State var image:Data?
 	    var body: some View {
 	        ImagePicker(data: $image, encoding: .png)
-	            Image(data: image!)!
-	                .resizable()
-	                .aspectRatio(contentMode: .fill)
-	                .frame(width:200,height:200)
-	                .clipped()
-	        }
+	        Image(data: image!)!
+	            .resizable()
+	            .aspectRatio(contentMode: .fill)
+	            .frame(width:200,height:200)
+	            .clipped()
+	    }
 	}
 The above code looks like:
 <p align="center">


### PR DESCRIPTION
The usage example for ImagePicker contains improper indentation that may be confusing to some readers. Originally, the indentations in the SwiftUI sample code in this file implied that `Image` belonged within a closure of `ImagePicker`; however, this creates an issue. `Image` should not be within a closure of `ImagePicker`, hence the change made.