### PR TITLE
Fixes cache use for LinkPreview

### DIFF
--- a/Sources/Intermodular/Helpers/LinkPresentation/LinkPresentationView.swift
+++ b/Sources/Intermodular/Helpers/LinkPresentation/LinkPresentationView.swift
@@ -181,6 +181,7 @@ struct _LinkPresentationView<Placeholder: View>: Identifiable, View {
         
         do {
             if let metadata = try cache.decache(LPLinkMetadata.self, forKey: url) {
+            if let url = url, let metadata = try cache.decache(LPLinkMetadata.self, forKey: url) {
                 self.fetchedMetadata = metadata
             }
         } catch {

--- a/Sources/Intermodular/Helpers/LinkPresentation/LinkPresentationView.swift
+++ b/Sources/Intermodular/Helpers/LinkPresentation/LinkPresentationView.swift
@@ -180,7 +180,6 @@ struct _LinkPresentationView<Placeholder: View>: Identifiable, View {
         }
         
         do {
-            if let metadata = try cache.decache(LPLinkMetadata.self, forKey: url) {
             if let url = url, let metadata = try cache.decache(LPLinkMetadata.self, forKey: url) {
                 self.fetchedMetadata = metadata
             }


### PR DESCRIPTION
I was wondering why the cache never got a hit, we were storing optionals here but looking for non-optional URL later.