### PR TITLE
Can add smart quotes type setting in CocoaTextField?

### DIFF
--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -39,6 +39,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
         var inputView: AnyView?
         var kerning: CGFloat?
         var keyboardType: UIKeyboardType = .default
+        var smartQuotesType: UITextSmartQuotesType = .no
         var placeholder: String?
         var returnKeyType: UIReturnKeyType?
         var textColor: UIColor?
@@ -221,6 +222,7 @@ fileprivate struct _CocoaTextField<Label: View>: UIViewRepresentable {
         
         uiView.isUserInteractionEnabled = context.environment.isEnabled
         uiView.keyboardType = configuration.keyboardType
+        uiView.smartQuotesType = configuration.smartQuotesType
         
         if let placeholder = configuration.placeholder {
             uiView.attributedPlaceholder = NSAttributedString(

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -39,7 +39,7 @@ public struct CocoaTextField<Label: View>: CocoaView {
         var inputView: AnyView?
         var kerning: CGFloat?
         var keyboardType: UIKeyboardType = .default
-        var smartQuotesType: UITextSmartQuotesType = .no
+        var smartQuotesType: UITextSmartQuotesType = .default
         var placeholder: String?
         var returnKeyType: UIReturnKeyType?
         var textColor: UIColor?

--- a/Sources/Intramodular/Bridged/CocoaTextField.swift
+++ b/Sources/Intramodular/Bridged/CocoaTextField.swift
@@ -429,6 +429,10 @@ extension CocoaTextField {
         then({ $0.configuration.keyboardType = keyboardType })
     }
     
+    public func smartQuotesType(_ smartQuotesType: UITextSmartQuotesType) -> Self {
+        then({ $0.configuration.smartQuotesType = smartQuotesType })
+    }
+    
     public func placeholder(_ placeholder: String) -> Self {
         then({ $0.configuration.placeholder = placeholder })
     }


### PR DESCRIPTION
Because my app use SwiftUIX's textfield and found a bug when input quotation mark. When users input quotation mark in English, it will show full width.