### PR TITLE
SwiftUI.Color conversion to UIColor update in PageControl.swift file

### DIFF
--- a/Sources/Intramodular/Pagination/PageControl.swift
+++ b/Sources/Intramodular/Pagination/PageControl.swift
@@ -63,7 +63,7 @@ extension PageControl: UIViewRepresentable {
         context.coordinator.base = self
         
         uiView.currentPage = currentPage.wrappedValue
-        uiView.currentPageIndicatorTintColor = context.environment.currentPageIndicatorTintColor?.toUIColor3()
+        uiView.currentPageIndicatorTintColor = context.environment.currentPageIndicatorTintColor?.toUIColor()
         uiView.numberOfPages = numberOfPages
         uiView.pageIndicatorTintColor = context.environment.pageIndicatorTintColor?.toUIColor()
         


### PR DESCRIPTION
changed method for SwiftUI.Color conversion to UIColor, so that any custom color can now be set for current pagerView dot, not only system ones