### PR TITLE
SwiftUI Color with opacity to UIColor conversion on iOS13

### DIFF
--- a/Sources/Intermodular/Helpers/AppKit or UIKit/AppKitOrUIKitColor+.swift
+++ b/Sources/Intermodular/Helpers/AppKit or UIKit/AppKitOrUIKitColor+.swift
@@ -98,6 +98,14 @@ extension Color {
             }
         }
         
+        if String(describing: type(of: base)) == "OpacityColor" {
+            let baseOpacity = Mirror(reflecting: base)
+            if let opacity = baseOpacity.descendant("opacity") as? Double,
+               let colorBase = baseOpacity.descendant("base") as? Color {
+                return colorBase.toUIColor()?.withAlphaComponent(CGFloat(opacity))
+            }
+        }
+        
         var baseValue: String = ""
         
         dump(base, to: &baseValue)


### PR DESCRIPTION
added ability to convert SwiftUI Color WITH OPACITY to UIColor on iOS13 platform 