### PR TITLE
Fixes cannot edit text when passing placeholder to init

### DIFF
--- a/Sources/Intramodular/Text/TextView.swift
+++ b/Sources/Intramodular/Text/TextView.swift
@@ -341,7 +341,7 @@ extension TextView: DefaultTextInputType where Label == Text {
         self.label = Text(title).foregroundColor(.placeholderText)
         self.text = text
         self.configuration = .init(
-            isConstant: true,
+            isConstant: false,
             onEditingChanged: onEditingChanged,
             onCommit: onCommit
         )


### PR DESCRIPTION
[Issue 278](https://github.com/SwiftUIX/SwiftUIX/issues/278#issue-937829638) is fixed by setting `configuration.isConstant` to `false` as is done when using the init without a placeholder text param.  