### PR TITLE
Fix unshaped rectangle behaviour in macOS when corner radius is higher than width or height

### DIFF
--- a/Sources/Intermodular/Extensions/AppKit or UIKit/AppKitOrUIKitBezierPath++.swift
+++ b/Sources/Intermodular/Extensions/AppKit or UIKit/AppKitOrUIKitBezierPath++.swift
@@ -21,17 +21,61 @@ extension AppKitOrUIKitBezierPath {
         #elseif os(macOS)
         self.init()
         
-        let topLeft = NSPoint(x: rect.minX, y: rect.minY)
-        let topRight = NSPoint(x: rect.maxX, y: rect.minY)
-        let bottomRight = NSPoint(x: rect.maxX, y: rect.maxY)
-        let bottomLeft = NSPoint(x: rect.minX, y: rect.maxY)
-        
-        move(to: CGPoint(x: topLeft.x, y: topLeft.y + cornerRadii))
-        
-        appendArc(from: topLeft, to: topRight, radius: corners.contains(.topLeading) ? cornerRadii : 0)
-        appendArc(from: topRight, to: bottomRight, radius: corners.contains(.topTrailing) ? cornerRadii : 0)
-        appendArc(from: bottomRight, to: bottomLeft, radius: corners.contains(.bottomTrailing) ? cornerRadii : 0)
-        appendArc(from: bottomLeft, to: topLeft, radius: corners.contains(.bottomLeading) ? cornerRadii : 0)
+        let cornerRadius: CGFloat = min(cornerRadii, min(rect.midY, rect.midX))
+        let (maxX, minX, maxY, minY, midX, midY) = (rect.size.width, CGFloat(0), rect.size.height, CGFloat(0), rect.midX, rect.midY)
+
+        let topCenter = CGPoint(x: midX, y: minY)
+        let topTrailing = CGPoint(x: maxX, y: minY)
+        let trailingCenter = CGPoint(x: maxX, y: midY)
+        move(to: topCenter)
+        if corners.contains(.topTrailing) {
+            let x = maxX - cornerRadius
+            let y = minY + cornerRadius
+            line(to: CGPoint(x: max(x, midX), y: minY))
+            appendArc(withCenter: CGPoint(x: x, y: y), radius: cornerRadius, startAngle: 270, endAngle: 0)
+            line(to: CGPoint(x: maxX, y: min(y, midY)))
+        } else {
+            line(to: topTrailing)
+            line(to: trailingCenter)
+        }
+
+        let bottomTrailing = CGPoint(x: maxX, y: maxY)
+        let bottomCenter = CGPoint(x: midX, y: maxY)
+        if corners.contains(.bottomTrailing) {
+            let x = maxX - cornerRadius
+            let y = maxY - cornerRadius
+            line(to: CGPoint(x: maxX, y: max(y, midY)))
+            appendArc(withCenter: CGPoint(x: x, y: y), radius: cornerRadius, startAngle: 0, endAngle: 90)
+            line(to: CGPoint(x: max(x, midX), y: maxY))
+        } else {
+            line(to: bottomTrailing)
+            line(to: bottomCenter)
+        }
+
+        let bottomLeading = CGPoint(x: minX, y: maxY)
+        let leadingCenter = CGPoint(x: minX, y: midY)
+        if corners.contains(.bottomLeading) {
+            let x = min(minX + cornerRadius, midX)
+            let y = max(maxY - cornerRadius, midY)
+            line(to: CGPoint(x: x, y: maxY))
+            appendArc(withCenter: CGPoint(x: minX + cornerRadius, y: maxY - cornerRadius), radius: cornerRadius, startAngle: 90, endAngle: 180)
+            line(to: CGPoint(x: minX, y: y))
+        } else {
+            line(to: bottomLeading)
+            line(to: leadingCenter)
+        }
+
+        let topLeading = CGPoint(x: minX, y: minY)
+        if corners.contains(.topLeading) {
+            let x = min(minX + cornerRadius, midX)
+            let y = min(minY + cornerRadius, midY)
+            line(to: CGPoint(x: minX, y: y))
+            appendArc(withCenter: CGPoint(x: minX + cornerRadius, y: minY + cornerRadius), radius: cornerRadius, startAngle: 180, endAngle: 270)
+            line(to: CGPoint(x: x, y: minY))
+        } else {
+            line(to: topLeading)
+            line(to: topCenter)
+        }
         
         close()
         #endif


### PR DESCRIPTION
If corner radius is higher than the half of width or height of a rectangle, `NSBezierPath` produces the unshaped rectangle in macOS while, in iOS, `UIBezierPath` takes the minimum value of the halves of width and height as corner radius. I just modified drawing of a rectangle with specific corner radius in `NSBezierPath` to get the same behaviour as `UIBezierPath` in iOS.