### PR TITLE
Remove navigator from accessibility hiererarchy

### DIFF
--- a/Sources/Intramodular/Navigation/SelectionNavigator.swift
+++ b/Sources/Intramodular/Navigation/SelectionNavigator.swift
@@ -51,6 +51,7 @@ fileprivate struct SelectionNavigator<Selection: Identifiable, Destination: View
                     label: { ZeroSizeView() }
                 )
                 .id(selection.id)
+                .accessibility(hidden: true)
             }
         )
         #else
@@ -62,6 +63,7 @@ fileprivate struct SelectionNavigator<Selection: Identifiable, Destination: View
                     label: { ZeroSizeView() }
                 )
                 .id(selection.id)
+                .accessibility(hidden: true)
             }
         )
         #endif
@@ -81,6 +83,7 @@ extension View {
                 isActive: isActive,
                 label: { ZeroSizeView() }
             )
+            .accessibility(hidden: true)
         )
     }
     
@@ -104,6 +107,7 @@ extension View {
                 ),
                 label: { ZeroSizeView() }
             )
+            .accessibility(hidden: true)
         )
     }
         
@@ -179,6 +183,7 @@ fileprivate struct NavigateOnPress<Destination: View>: ViewModifier {
                 label: { EmptyView() }
             )
             .hidden()
+            .accessibility(hidden: true)
         )
     }
 }


### PR DESCRIPTION
Hide the navigationLinks from accessibility because it interferred with voice over in incorrect way. If i put a navigateToLink on the background view which i do all the time to implement programmatical navigation in voice over i get that it is a button on the background of view