### PR TITLE
Make NavigationPresentationManager initializer public

### DIFF
--- a/Sources/Intramodular/Presentation/Link/NavigationPresentationLink.swift
+++ b/Sources/Intramodular/Presentation/Link/NavigationPresentationLink.swift
@@ -33,7 +33,7 @@ public struct NavigationPresentationLink<Label: View, Destination: View>: View {
 public struct NavigationPresentationManager: PresentationManager {
     let isActive: Binding<Bool>
     
-    init(isActive: Binding<Bool>) {
+    public init(isActive: Binding<Bool>) {
         self.isActive = isActive
     }
     


### PR DESCRIPTION
This seems useful for situations where you want to rely on a `presentationManager` in the environment, but do not want the link itself to own the `isActive` state, which is currently the only way to use `NavigationPresentationManager` in user code. Opening this initializer is particularly useful because it abstracts away the concrete mechanism of presentation on the side of the presented view, which then can simply rely on the environment. This doesn't work with SwiftUI's built-in `presentationMode` for `NavigationLink` afaik.

Example:
```swift
NavigationLink(
    destination: DetailView(item: item)
        .environment(\.presentationManager, NavigationPresentationManager(tag: item, selection: $selection),
    tag: item,
    selection: $selection
) {
    ItemView(item: item)
}
```

A useful extension for presenting with selection bindings here was:
```swift
extension NavigationPresentationManager {
    public init<T: Hashable>(tag: T, selection: Binding<T?>) {
        self.init(isActive: Binding(
            get: { selection.wrappedValue == tag },
            set: { isActive in
                if isActive {
                    selection.wrappedValue = tag
                } else {
                    selection.wrappedValue = nil
                }
            }
        ))
    }
}
```
This might be out-of-scope though for SwiftUIX, (?) and it can be defined in user code once the initializer is publicly accessible.