### PR TITLE
Fix CocoaScrollView layout bug

### DIFF
--- a/Sources/Intermodular/Helpers/UIKit/UIHostingScrollView.swift
+++ b/Sources/Intermodular/Helpers/UIKit/UIHostingScrollView.swift
@@ -44,8 +44,8 @@ open class UIHostingScrollView<Content: View>: UIScrollView, _opaque_UIHostingSc
             hostingContentView.rootView.content
         } set {
             hostingContentView.rootView.content = newValue
-            
-            update()
+
+            setNeedsLayout()
         }
     }
     
@@ -86,15 +86,14 @@ open class UIHostingScrollView<Content: View>: UIScrollView, _opaque_UIHostingSc
     public func contentOffset(forPageIndex pageIndex: Int) -> CGPoint {
         .zero
     }
-    
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        update()
+    }
+
     private func update() {
         guard !frame.size.isAreaZero else {
-            DispatchQueue.main.async {
-                if !self.frame.size.isAreaZero {
-                    self.update()
-                }
-            }
-            
             return
         }
         


### PR DESCRIPTION
We encountered a bug while trying to se `CocoaScrollView`. When the scrollview was removed and returned to the hierarchy it's content would never be rendered.
I've boiled it down to this minimum reproducible code, where if you switch the tabs very quickly the content of the first tab is not rendered. Also there are some issues with content size where it sometimes varies by the safe area insets.

```
struct ContentView: View {
    enum Tab {
        case first, second
    }

    @State var selectedTab = Tab.first
    @State var isRefreshing = false

    @State var items: [Int] = (0..<100).map { $0 }

    var body: some View {
        ZStack(alignment: .bottom) {
            tabView.frame(maxWidth: .infinity, maxHeight: .infinity)
            HStack {
                Button("Selected first tab") {
                    selectedTab = .first
                }
                Button("Selected second tab") {
                    selectedTab = .second
                }
            }
        }.edgesIgnoringSafeArea(.all)
    }

    @ViewBuilder var tabView: some View {
        switch selectedTab {
        case .first:
            CocoaScrollView {

                VStack(spacing: 0) {
                    Text("Is refreshing \(isRefreshing.description)").frame(height: 20)
                    ForEach(items, id: \.self) {
                        Text("Row \($0)")
                            .frame(maxWidth: .infinity)
                            .frame(height: 20)
                            .background(Color.yellow)
                    }
                }
            }.onRefresh {
                isRefreshing = true

                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
                    self.items = (0..<Int.random(in: (50..<150))).map { $0 }.shuffled()
                    self.isRefreshing = false
                }
            }
            .isRefreshing(isRefreshing)
            .frame(maxWidth: .infinity, maxHeight: .infinity)
            .background(Color.green)
        case .second:
            Text("Second")
        }
    }
}
```

Seems that the problem was that the dispatch in the `update` method wasn't always called after the frame is updated from zero value. I think a better place for the update method is in the `layoutSubviews` method that is called every time when the frame is updated, and if the content is updated by ensuring `setNeedsLayout` is called there.
The safe area insets problem seem to be fixed by this change too.
Let me know if I'm missing something.