### PR TITLE
Add public hostingController property

### DIFF
--- a/Sources/Intermodular/Helpers/UIKit/UIHostingView.swift
+++ b/Sources/Intermodular/Helpers/UIKit/UIHostingView.swift
@@ -155,6 +155,10 @@ extension UIHostingView {
     public func _fixSafeAreaInsets() {
         rootViewHostingController._fixSafeAreaInsets()
     }
+    
+    public var hostingController: UIViewController {
+        rootViewHostingController
+    }
 }
 
 #endif


### PR DESCRIPTION
While adding UIHostingController to UITableViewCell,  `willMove(toParent:)`, `addChild(_:)`, `didMove(toParent:)` is necessary,  as what `UIHostingTableViewCell` did. But there is no way to get `hostingController` of UIHostingView right now.