### PR TITLE
Improve checking if every value satisfies a condition

### DIFF
--- a/Sources/Intermodular/Extensions/SwiftUI/Alignment++.swift
+++ b/Sources/Intermodular/Extensions/SwiftUI/Alignment++.swift
@@ -20,7 +20,7 @@ extension Alignment {
     }
     
     public func isAligned(to edges: [Edge]) -> Bool {
-        edges.map(isAligned(to:)).reduce(true, { $0 && $1 })
+        edges.allSatisfy(isAligned(to:))
     }
 }
 

--- a/Sources/Intramodular/Collection View & List/_CollectionView.DataSource.swift
+++ b/Sources/Intramodular/Collection View & List/_CollectionView.DataSource.swift
@@ -302,9 +302,7 @@ fileprivate extension NSDiffableDataSourceSnapshot {
     mutating func applyItemDifference(
         _ difference: CollectionDifference<ItemIdentifierType>, inSection section: SectionIdentifierType
     ) -> Bool {
-        difference
-            .map({ applyItemChange($0, inSection: section) })
-            .reduce(true, { $0 && $1 })
+        difference.allSatisfy { applyItemChange($0, inSection: section) }
     }
     
     mutating func applyItemChange(


### PR DESCRIPTION
Hi,

This PR replaces `reduce(_:_:)` with `allSatisfy(_:)` to improve checking if every value satisfies a condition.
https://developer.apple.com/documentation/swift/array/allsatisfy(_:)