### PR TITLE
Improve finding the first element

### DIFF
--- a/Sources/Intermodular/Extensions/UIKit/UIPageViewController++.swift
+++ b/Sources/Intermodular/Extensions/UIKit/UIPageViewController++.swift
@@ -21,7 +21,7 @@ extension UIPageViewController {
             #if os(tvOS)
             return false
             #else
-            return gestureRecognizers.filter({ $0 is UIScreenEdgePanGestureRecognizer }).first?.isEnabled ?? true
+            return gestureRecognizers.first(where: { $0 is UIScreenEdgePanGestureRecognizer })?.isEnabled ?? true
             #endif
         } set {
             #if !os(tvOS)
@@ -32,7 +32,7 @@ extension UIPageViewController {
     
     var isTapGestureEnabled: Bool {
         get {
-            gestureRecognizers.filter({ $0 is UITapGestureRecognizer }).first?.isEnabled ?? true
+            gestureRecognizers.first(where: { $0 is UITapGestureRecognizer })?.isEnabled ?? true
         } set {
             gestureRecognizers.filter({ $0 is UITapGestureRecognizer }).forEach({ $0.isEnabled = newValue })
         }

--- a/Sources/Intermodular/Helpers/AppKit or UIKit/AppKitOrUIKitColor+.swift
+++ b/Sources/Intermodular/Helpers/AppKit or UIKit/AppKitOrUIKitColor+.swift
@@ -73,14 +73,14 @@ extension Color {
     
     private func toUIColor2() -> UIColor? {
         let children = Mirror(reflecting: self).children
-        let _provider = children.filter { $0.label == "provider" }.first
+        let _provider = children.first { $0.label == "provider" }
         
         guard let provider = _provider?.value else {
             return nil
         }
         
         let providerChildren = Mirror(reflecting: provider).children
-        let _base = providerChildren.filter { $0.label == "base" }.first
+        let _base = providerChildren.first { $0.label == "base" }
         
         guard let base = _base?.value else {
             return nil

--- a/Sources/Intramodular/Drag & Drop/_DragSourceDropDestinationView.swift
+++ b/Sources/Intramodular/Drag & Drop/_DragSourceDropDestinationView.swift
@@ -71,7 +71,7 @@ struct _DragSourceDropDestinationView<
                 viewController.view.addInteraction(context.coordinator.dragInteraction)
             }
             
-            if let longPressRecognizer = viewController.view.gestureRecognizers?.compactMap({ $0 as? UILongPressGestureRecognizer}).filter({ NSStringFromClass(type(of: $0)).contains("Drag") }).first {
+            if let longPressRecognizer = viewController.view.gestureRecognizers?.compactMap({ $0 as? UILongPressGestureRecognizer}).first(where: { NSStringFromClass(type(of: $0)).contains("Drag") }) {
                 if longPressRecognizer.minimumPressDuration != 0 {
                     longPressRecognizer.minimumPressDuration = 0
                 }


### PR DESCRIPTION
Hi,

This PR replaces `filter(_:)` + `first` with `first(where:)` to improve finding the first element.
https://developer.apple.com/documentation/swift/array/first(where:)