### PR TITLE
Added the ability to set nil Instead of color to set the default color. 

### DIFF
--- a/Sources/SwiftUIX/Intermodular/Helpers/SwiftUI/View.sheetBackground.swift
+++ b/Sources/SwiftUIX/Intermodular/Helpers/SwiftUI/View.sheetBackground.swift
@@ -12,7 +12,7 @@ extension View {
     ///
     /// This implementation relies on the assumpion that a SwiftUI sheet is backed by a `UIViewController` or an `NSViewController`.
     /// Use `Color.clear` if you wish to set the underlying view controller's `view.backgroundColor` to `nil`.
-    public func sheetBackground(_ color: Color) -> some View {
+    public func sheetBackground(_ color: Color?) -> some View {
         modifier(_UpdateSheetBackground(color: color))
     }
 }
@@ -20,8 +20,8 @@ extension View {
 // MARK: - Auxiliary
 
 struct _UpdateSheetBackground: ViewModifier {
-    let color: Color
-    
+    let color: Color?
+
     @State private var didSet: Bool = false
     
     func body(content: Content) -> some View {
@@ -35,8 +35,8 @@ struct _UpdateSheetBackground: ViewModifier {
             }
             
             #if os(iOS) || os(tvOS)
-            let newBackgroundColor = color == .clear ? color.toUIColor() : nil
-            
+            let newBackgroundColor = color == .clear ? color?.toUIColor() : nil
+
             (viewController.root ?? viewController).view.backgroundColor = newBackgroundColor
             #else
             if #available(macOS 11, *) {

--- a/Sources/SwiftUIX/Intermodular/Helpers/UIKit/View.configureUINavigationController.swift
+++ b/Sources/SwiftUIX/Intermodular/Helpers/UIKit/View.configureUINavigationController.swift
@@ -52,18 +52,18 @@ extension View {
     /// - Parameters:
     ///     - color: The color to use for the navigation bar.
     @inlinable
-    public func navigationBarColor(_ color: Color) -> some View {
+    public func navigationBarColor(_ color: Color?) -> some View {
         _configureUINavigationBar { navigationBar in
-            navigationBar.backgroundColor = color.toUIColor()
-            navigationBar.barTintColor = color.toUIColor()
+            navigationBar.backgroundColor = color?.toUIColor()
+            navigationBar.barTintColor = color?.toUIColor()
         }
     }
     
     /// Configures the tint color of the navigation bar for this view.
     @inlinable
-    public func navigationBarTint(_ color: Color) -> some View {
+    public func navigationBarTint(_ color: Color?) -> some View {
         _configureUINavigationBar { navigationBar in
-            navigationBar.tintColor = color.toAppKitOrUIKitColor()
+            navigationBar.tintColor = color?.toAppKitOrUIKitColor()
         }
     }
 

--- a/Sources/SwiftUIX/Intramodular/Pagination/PageControl.swift
+++ b/Sources/SwiftUIX/Intramodular/Pagination/PageControl.swift
@@ -113,12 +113,12 @@ extension View {
     }
     
     @inlinable
-    public func pageIndicatorTintColor(_ color: Color) -> some View {
+    public func pageIndicatorTintColor(_ color: Color?) -> some View {
         environment(\.pageIndicatorTintColor, color)
     }
     
     @inlinable
-    public func currentPageIndicatorTintColor(_ color: Color) -> some View {
+    public func currentPageIndicatorTintColor(_ color: Color?) -> some View {
         environment(\.currentPageIndicatorTintColor, color)
     }
 }

--- a/Sources/SwiftUIX/Intramodular/Search Bar/SearchBar.swift
+++ b/Sources/SwiftUIX/Intramodular/Search Bar/SearchBar.swift
@@ -128,20 +128,15 @@ extension SearchBar: UIViewRepresentable {
         style: do {
             uiView.searchTextField.autocorrectionType = environment.disableAutocorrection.map({ $0 ? .no : .yes }) ?? .default
             
-            if (appKitOrUIKitFont != nil || environment.font != nil) || appKitOrUIKitForegroundColor != nil || appKitOrUIKitSearchFieldBackgroundColor != nil {
+            if (appKitOrUIKitFont != nil || environment.font != nil) {
                 if let font = try? appKitOrUIKitFont ?? environment.font?.toAppKitOrUIKitFont() {
                     uiView.searchTextField.font = font
                 }
-                
-                if let foregroundColor = appKitOrUIKitForegroundColor {
-                    uiView.searchTextField.textColor = foregroundColor
-                }
-                
-                if let backgroundColor = appKitOrUIKitSearchFieldBackgroundColor {
-                    uiView.searchTextField.backgroundColor = backgroundColor
-                }
             }
-            
+
+            uiView.searchTextField.backgroundColor = appKitOrUIKitSearchFieldBackgroundColor
+            uiView.searchTextField.textColor = appKitOrUIKitForegroundColor
+
             if let placeholder = placeholder {
                 uiView.placeholder = placeholder
             }
@@ -409,23 +404,23 @@ extension SearchBar {
         self.font(AppKitOrUIKitFont(name: font.rawValue, size: size))
     }
 
-    public func foregroundColor(_ foregroundColor: AppKitOrUIKitColor) -> Self {
+    public func foregroundColor(_ foregroundColor: AppKitOrUIKitColor?) -> Self {
         then({ $0.appKitOrUIKitForegroundColor = foregroundColor })
     }
     
     #if os(iOS) || targetEnvironment(macCatalyst)
     @_disfavoredOverload
-    public func foregroundColor(_ foregroundColor: Color) -> Self {
-        then({ $0.appKitOrUIKitForegroundColor = foregroundColor.toUIColor() })
+    public func foregroundColor(_ foregroundColor: Color?) -> Self {
+        then({ $0.appKitOrUIKitForegroundColor = foregroundColor?.toUIColor() })
     }
     
-    public func textFieldBackgroundColor(_ backgroundColor: UIColor) -> Self {
+    public func textFieldBackgroundColor(_ backgroundColor: UIColor?) -> Self {
         then({ $0.appKitOrUIKitSearchFieldBackgroundColor = backgroundColor })
     }
     
     @_disfavoredOverload
-    public func textFieldBackgroundColor(_ backgroundColor: Color) -> Self {
-        then({ $0.appKitOrUIKitSearchFieldBackgroundColor = backgroundColor.toUIColor() })
+    public func textFieldBackgroundColor(_ backgroundColor: Color?) -> Self {
+        then({ $0.appKitOrUIKitSearchFieldBackgroundColor = backgroundColor?.toUIColor() })
     }
     
     public func searchBarStyle(_ searchBarStyle: UISearchBar.Style) -> Self {

--- a/Sources/SwiftUIX/Intramodular/Text/AttributedText.swift
+++ b/Sources/SwiftUIX/Intramodular/Text/AttributedText.swift
@@ -74,8 +74,8 @@ extension AttributedText {
     
     #if os(iOS) || os(tvOS) || os(visionOS) || targetEnvironment(macCatalyst)
     @_disfavoredOverload
-    public func foregroundColor(_ foregroundColor: Color) -> Self {
-        then({ $0.configuration.appKitOrUIKitForegroundColor = foregroundColor.toUIColor() })
+    public func foregroundColor(_ foregroundColor: Color?) -> Self {
+        then({ $0.configuration.appKitOrUIKitForegroundColor = foregroundColor?.toUIColor() })
     }
     #endif
 }

--- a/Sources/SwiftUIX/Intramodular/Text/CocoaTextField.swift
+++ b/Sources/SwiftUIX/Intramodular/Text/CocoaTextField.swift
@@ -206,7 +206,7 @@ fileprivate struct _CocoaTextField<Label: View>: UIViewRepresentable {
             uiView.smartQuotesType = configuration.smartQuotesType ?? .default
             uiView.spellCheckingType = configuration.spellCheckingType ?? .default
             uiView.textAlignment = .init(context.environment.multilineTextAlignment)
-            uiView.textColor = configuration.textColor ?? uiView.textColor
+            uiView.textColor = configuration.textColor
             uiView.textContentType = configuration.textContentType
             uiView.tintColor = context.environment.tintColor?.toUIColor()
             
@@ -418,18 +418,18 @@ extension CocoaTextField {
         then({ $0.configuration.placeholder = placeholder })
     }
     
-    public func foregroundColor(_ foregroundColor: Color) -> Self {
-        then({ $0.configuration.textColor = foregroundColor.toUIColor() })
+    public func foregroundColor(_ foregroundColor: Color?) -> Self {
+        then({ $0.configuration.textColor = foregroundColor?.toUIColor() })
     }
     
     @_disfavoredOverload
-    public func foregroundColor(_ foregroundColor: UIColor) -> Self {
+    public func foregroundColor(_ foregroundColor: UIColor?) -> Self {
         then({ $0.configuration.textColor = foregroundColor })
     }
     
     @available(*, deprecated, renamed: "foregroundColor")
-    public func textColor(_ foregroundColor: Color) -> Self {
-        then({ $0.configuration.textColor = foregroundColor.toUIColor() })
+    public func textColor(_ foregroundColor: Color?) -> Self {
+        then({ $0.configuration.textColor = foregroundColor?.toUIColor() })
     }
 }
 


### PR DESCRIPTION
When setting nil, the default color is shown and set in color variable.

For example, you can set a custom color for the NavigationBar via the Appearance singleton, and change it to red on the screen during an error, and when there is no error, set nil and UIKit will return the default color (from Appearance). 

Changes to the api **don't break backward compatibility**. 

These changes improve the developer experience of using the framework. Will make the api more native. 