### PR TITLE
Fix window overlay bug

### DIFF
--- a/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
+++ b/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
@@ -119,8 +119,11 @@ public final class _WindowPresentationController<Content: View>: _AnyWindowPrese
             
             _isVisible = newValue
             
-            if _contentWindow == nil || _isVisible == isVisible
-            {
+            if let _contentWindow {
+                if _contentWindow.isVisible != _isVisible {
+                    _setNeedsUpdate()
+                }
+            } else {
                 _setNeedsUpdate()
             }
         }

--- a/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
+++ b/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
@@ -119,7 +119,8 @@ public final class _WindowPresentationController<Content: View>: _AnyWindowPrese
             
             _isVisible = newValue
             
-            if _contentWindow == nil {
+            if _contentWindow == nil || _isVisible == isVisible
+            {
                 _setNeedsUpdate()
             }
         }


### PR DESCRIPTION
Fixes a bug where the window presented by `windowOverlay` was not correctly being dismissed. 

`_isVisible`'s setter was not correctly calling `_setNeedsUpdate` when required, updated an if statement within the setter to now update the view and dismiss it when the binding changes.