### PR TITLE
Bump package Swift version to 5.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 
 import PackageDescription
 


### PR DESCRIPTION
If possible, we could bump the package Swift version to 5.10, as it brings us more DocC capabilities, such as new controls and the possibility to link to external type extensions.

This *should* involve a major version bump when honoring semver, but perhaps that's not a concern for this package at this time?

However, feel free to close this if you don't think it's a good move.