### PR TITLE
Update _SwiftUIX_KeyPress.swift

### DIFF
--- a/Sources/SwiftUIX/Intramodular/Event Handling/_SwiftUIX_KeyPress.swift
+++ b/Sources/SwiftUIX/Intramodular/Event Handling/_SwiftUIX_KeyPress.swift
@@ -85,6 +85,7 @@ extension View {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension View {
+    @MainActor
     public func _SwiftUIX_onKeyPress(
         phases: _SwiftUIX_KeyPress.Phases = [.down, .repeat],
         action: @escaping @MainActor (_SwiftUIX_KeyPress) -> _SwiftUIX_KeyPress.Result
@@ -151,6 +152,7 @@ extension View {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension View {
+    @MainActor
     public func _overrideOnMoveCommand(
         perform action: (@MainActor (_SwiftUIX_MoveCommandDirection) -> _SwiftUIX_KeyPress.Result)?
     ) -> some View {
@@ -166,7 +168,8 @@ extension View {
             return action(command)
         }
     }
-    
+
+    @MainActor
     public func _overrideOnExitCommand(
         perform action: (@MainActor () -> _SwiftUIX_KeyPress.Result)?
     ) -> some View {
@@ -183,6 +186,7 @@ extension View {
         }
     }
     
+    @MainActor
     public func _overrideOnExitCommand(
         perform action: (@MainActor () -> Void)?
     ) -> some View {
@@ -197,6 +201,7 @@ extension View {
         }
     }
     
+    @MainActor
     public func _overrideOnDeleteCommand(
         perform action: (@MainActor () -> _SwiftUIX_KeyPress.Result)?
     ) -> some View {
@@ -212,7 +217,8 @@ extension View {
             return action()
         }
     }
-    
+
+    @MainActor
     public func _overrideOnDeleteCommand(
         perform action: (@MainActor () -> Void)?
     ) -> some View {


### PR DESCRIPTION
In Xcode 15.4 with Swift 5.10, `SwiftUI.View` is not annotated with `@MainActor`. As a result, when the flags are enabled in Swift 6, an error appears: "Call to main actor-isolated let 'action' in a synchronous nonisolated context." 
This is a simple fix for those who are not using the macOS beta with the new Xcode and Swift 6.