### PR TITLE
Fix incorrect documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,4 +309,4 @@ SwiftUIX is led and maintained by [@vatsal_manot](http://twitter.com/vatsal_mano
 Special thanks to [Brett Best](https://github.com/Brett-Best), [Nathan Tanner](https://github.com/nathantannar4), [Kabir Oberai](https://github.com/kabiroberai) and many more.
 
 
-[Documentation]: [https://swiftuix.github.io/SwiftUIX/documentation/swiftuix/]
+[Documentation]: https://swiftuix.github.io/SwiftUIX


### PR DESCRIPTION
The recent changes to this URL were incorrect, since the suffix is in fact lower-cased.

However, since I inject a redirect into the doc root, we can skip this suffix altogether.