### PR TITLE
Update _PlatformTextView.swift for visionOS

### DIFF
--- a/Sources/SwiftUIX/Intramodular/Text/_PlatformTextView.swift
+++ b/Sources/SwiftUIX/Intramodular/Text/_PlatformTextView.swift
@@ -197,7 +197,7 @@ open class _AnyPlatformTextView: AppKitOrUIKitTextView, AppKitOrUIKitTextInputDe
     
     // MARK: - UITextInputDelegate
 
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
     open func selectionWillChange(_ textInput: (any UITextInput)?) {
 
     }


### PR DESCRIPTION
This pull request includes a small update to the `_PlatformTextView` implementation in `Sources/SwiftUIX/Intramodular/Text/_PlatformTextView.swift`. The change adds support for `visionOS` by updating a preprocessor directive.

* Updated the preprocessor directive in `_AnyPlatformTextView` to include `os(visionOS)` for compatibility with the new platform.