### PR TITLE
feat(window-overlay): add level property

### DIFF
--- a/Sources/SwiftUIX/Intramodular/Window/WindowOverlay.swift
+++ b/Sources/SwiftUIX/Intramodular/Window/WindowOverlay.swift
@@ -15,15 +15,18 @@ struct WindowOverlay<Content: View>: AppKitOrUIKitViewControllerRepresentable {
     private let content: Content
     private let canBecomeKey: Bool
     private let isVisible: Binding<Bool>
+    private let level: CGFloat?
 
     init(
         content: Content,
         canBecomeKey: Bool,
-        isVisible: Binding<Bool>
+        isVisible: Binding<Bool>,
+        level: CGFloat?
     ) {
         self.content = content
         self.canBecomeKey = canBecomeKey
         self.isVisible = isVisible
+        self.level = level
     }
     
     func makeAppKitOrUIKitViewController(
@@ -32,7 +35,8 @@ struct WindowOverlay<Content: View>: AppKitOrUIKitViewControllerRepresentable {
         AppKitOrUIKitViewControllerType(
             content: content,
             canBecomeKey: canBecomeKey,
-            isVisible: isVisible.wrappedValue
+            isVisible: isVisible.wrappedValue,
+            level: level
         )
     }
     
@@ -68,11 +72,12 @@ extension WindowOverlay {
     class AppKitOrUIKitViewControllerType: AppKitOrUIKitViewController {
         var windowPresentationController: _WindowPresentationController<Content>
         
-        init(content: Content, canBecomeKey: Bool, isVisible: Bool) {
+        init(content: Content, canBecomeKey: Bool, isVisible: Bool, level: CGFloat?) {
             self.windowPresentationController = _WindowPresentationController(
                 content: content,
                 canBecomeKey: canBecomeKey,
-                isVisible: isVisible
+                isVisible: isVisible,
+                level: level
             )
 
             super.init(nibName: nil, bundle: nil)
@@ -109,13 +114,15 @@ extension View {
     ///   - content: A closure returning the content of the window.
     public func windowOverlay<Content: View>(
         isVisible: Binding<Bool>,
+        level: CGFloat? = nil,
         @ViewBuilder _ content: () -> Content
     ) -> some View {
         background(
             WindowOverlay(
                 content: content(),
                 canBecomeKey: false,
-                isVisible: isVisible
+                isVisible: isVisible,
+                level: level
             )
         )
     }
@@ -127,13 +134,15 @@ extension View {
     ///   - content: A closure returning the content of the window.
     public func windowOverlay<Content: View>(
         isKeyAndVisible: Binding<Bool>,
+        level: CGFloat? = nil,
         @ViewBuilder _ content: () -> Content
     ) -> some View {
         background(
             WindowOverlay(
                 content: content(),
                 canBecomeKey: true,
-                isVisible: isKeyAndVisible
+                isVisible: isKeyAndVisible,
+                level: level
             )
         )
     }

--- a/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
+++ b/Sources/SwiftUIX/Intramodular/Window/_WindowPresentationController.swift
@@ -60,6 +60,7 @@ public final class _WindowPresentationController<Content: View>: _AnyWindowPrese
     
     @Published
     package var _isVisible: Bool = false
+    package var level: CGFloat?
     package var _externalIsVisibleBinding: Binding<Bool>?
     
     private var _updateWorkItem: DispatchWorkItem?
@@ -167,11 +168,13 @@ public final class _WindowPresentationController<Content: View>: _AnyWindowPrese
         content: ContentBacking,
         windowStyle: _WindowStyle = .default,
         canBecomeKey: Bool,
-        isVisible: Bool
+        isVisible: Bool,
+        level: CGFloat? = nil
     ) {
         self.configuration = .init(style: windowStyle, canBecomeKey: canBecomeKey)
         self._content = content
         self._isVisible = isVisible
+        self.level = level
         
         super.init()
 
@@ -268,7 +271,7 @@ extension _WindowPresentationController {
             #endif
             
             #if os(iOS) || os(tvOS)
-            contentWindow._assignIfNotEqual(UIWindow.Level(rawValue: keyAppWindow.windowLevel.rawValue + 1), to: \.windowLevel)
+            contentWindow._assignIfNotEqual(UIWindow.Level(rawValue: level ?? keyAppWindow.windowLevel.rawValue + 1), to: \.windowLevel)
             #endif
             
             contentWindow._sizeWindowToNonZeroFitThenPerform { [weak self] in
@@ -350,13 +353,15 @@ extension _WindowPresentationController {
         content: Content,
         windowStyle: _WindowStyle = .default,
         canBecomeKey: Bool,
-        isVisible: Bool
+        isVisible: Bool,
+        level: CGFloat? = nil
     ) {
         self.init(
             content: .view(content),
             windowStyle: windowStyle,
             canBecomeKey: canBecomeKey,
-            isVisible: isVisible
+            isVisible: isVisible,
+            level: level
         )
     }
     


### PR DESCRIPTION
This PR adds a level property to the WindowOverlay view. This allows us to determine the order of which multiple window overlays are shown when multiple are active. Without this property, the view that is presented the latest will be placed on top.