### PR TITLE
Support greedy frame with `fixedSize` modifier

### DIFF
--- a/Sources/SwiftUIX/Intermodular/Helpers/SwiftUI/View.frame+.swift
+++ b/Sources/SwiftUIX/Intermodular/Helpers/SwiftUI/View.frame+.swift
@@ -393,10 +393,10 @@ struct GreedyFrameModifier: _opaque_FrameModifier, ViewModifier {
     func body(content: Content) -> some View {
         content.frame(
             minWidth: width?.fixedValue,
-            idealWidth: width?.resolve(in: .greatestFiniteDimensions),
+            idealWidth: width?.fixedValue,
             maxWidth: width?.resolve(in: .greatestFiniteDimensions),
             minHeight: height?.fixedValue,
-            idealHeight: height?.resolve(in: .greatestFiniteDimensions),
+            idealHeight: height?.fixedValue,
             maxHeight: height?.resolve(in: .greatestFiniteDimensions),
             alignment: alignment
         )


### PR DESCRIPTION
We can omit ideal size and preserve greedy behavior. That way we can pair it with fixedSize:

```
SomeView()
   .frame(width: .greedy)
   .fixedSize(horizontal: isHuggingEnabled, vertical: false)
```

It is rare scenario, but it would be nice to have